### PR TITLE
[LOPS-1850] Update curl for 3.x image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN apk update && apk add bash jq mysql mysql-client && \
   mkdir /scripts && \
   rm -rf /var/cache/apk/*
 
+# Update curl
+RUN apk add --no-cache curl && apk add --upgrade --no-cache curl
+
 VOLUME ["/var/lib/mysql"]
 
 # Install mysql PHP library.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ This is the source Dockerfile for the [pantheon-public/docker-updatinator](https
 In CircleCI 2.0:
 ```
   docker:
-    - image: quay.io/pantheon-public/docker-updatinator:1.x
+    - image: quay.io/pantheon-public/docker-updatinator:3.x
 ```
+
+## Branches
+
+- 3.x: Supported
+- Any other branch: Unsupported.
 
 ## Image Contents
 


### PR DESCRIPTION
Before:

curl --version
curl 7.83.1 (x86_64-alpine-linux-musl) libcurl/7.83.1 OpenSSL/1.1.1s zlib/1.2.12 brotli/1.0.9 nghttp2/1.47.0
Release-Date: 2022-05-11
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL TLS-SRP UnixSockets

After:

curl --version
curl 8.4.0 (x86_64-alpine-linux-musl) libcurl/8.4.0 OpenSSL/1.1.1w zlib/1.2.12 brotli/1.0.9 nghttp2/1.47.0
Release-Date: 2023-10-11
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IPv6 Largefile libz NTLM SSL threadsafe TLS-SRP UnixSockets